### PR TITLE
Ungitignore type-level-sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /dist/
 /dist-newstyle/
 /.stack-work/
-type-level-sets-0.7/


### PR DESCRIPTION
After all, it's needed in the stack.yaml.
