### PR TITLE
Implement from-record conversion with Generics

### DIFF
--- a/src/Bookkeeper.hs
+++ b/src/Bookkeeper.hs
@@ -37,6 +37,10 @@ module Bookkeeper
   , Book
   , (:=>)
   , Key
+
+  -- * From Haskell record
+  , fromRecord
+
   -- * Re-exports
   , (&)
 


### PR DESCRIPTION
Hi,

I found this issue: https://github.com/turingjump/bookkeeper/issues/22, and threw together a quick fromRecord implementation:

``` haskell
data Test = Test {
  field1 :: String,
  field2 :: Int,
  field3 :: Char
} deriving Generic
```

``` haskell
>>> fromRecord (Test "hello" 0 'c')
Book {field1 = "hello", field2 = 0, fields3 = 'c'}
```

It would probably be nice to provide some custom error message in case the provided data type is not a convertible record, i.e. not a data type with a single constructor that is a record. 
