### PR TITLE
Added package.yaml to package.yaml

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -14,6 +14,7 @@ category:            Data Structures, Records
 extra-source-files:
   - CHANGELOG.md
   - README.md
+  - package.yaml
 
 ghc-options: -Wall
 


### PR DESCRIPTION
`doctest` expects `package.yaml` to be present

``` haskell
main :: IO ()                                                                                                                                                 
main = do                                                                                                                                                     
  hpack' <- decodeFile "package.yaml"  
  ...
```

If not included in cabal file, hackage tarball won't include `package.yaml` either. This causes nix-builds to fail unless `nixpkgs.haskell.lib.dontCheck bookkeeper` is specified.
