### PR TITLE
add rlens and IsLabel instance for lenses

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ tests:
       - doctest >= 0.9 && < 0.12
       - Glob >= 0.7 && < 0.8
       - yaml == 0.8.*
+      - microlens
 
 benchmarks:
   bench:

--- a/package.yaml
+++ b/package.yaml
@@ -69,7 +69,6 @@ tests:
       - doctest >= 0.9 && < 0.12
       - Glob >= 0.7 && < 0.8
       - yaml == 0.8.*
-      - microlens
 
 benchmarks:
   bench:

--- a/src/Bookkeeper/Internal.hs
+++ b/src/Bookkeeper/Internal.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-warn-redundant-constraints -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 module Bookkeeper.Internal where
 
 import GHC.OverloadedLabels
@@ -206,38 +206,6 @@ delete :: forall field old .
         ( Map.Submap (Map.AsMap (old Map.:\ field)) old
         ) => Key field -> Book' old -> Book (old Map.:\ field)
 delete _ (Book bk) = Book $ Map.submap bk
-
--- * Lenses
-
--- | Build a lens from a field
---
--- @
--- julian ^. rlens #age
---    = 28
--- @
--- Symbols can also be used directly as lenses, so you probably don't need to use 'rlens':
---
--- @
--- julian ^. #age
---    = 28
--- @
---
--- @
--- julian & #age .~ 29
---    = Book {age = 29, name = "Julian K. Arni"}
--- @
-rlens :: (Settable field val' old new, Gettable field old val, Functor f) =>
-          Key field -> (val -> f val') -> (Book' old -> f (Book' new))
-rlens f = lens (\r -> get f r) (\r v -> set f v r)
-  where lens sa sbt afb s = sbt s <$> afb (sa s)
-
-instance (Settable field valnew old new,
-          Gettable field old val,
-          Functor f,
-          s2ft ~ (Book' old -> f (Book' new)))
-         => IsLabel (field :: Symbol)
-                    ((val -> f valnew) -> s2ft) where
-  fromLabel _ = rlens (Key @field)
 
 -- * Generics
 

--- a/src/Bookkeeper/Internal.hs
+++ b/src/Bookkeeper/Internal.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints -fno-warn-orphans #-}
 module Bookkeeper.Internal where
 
 import GHC.OverloadedLabels
@@ -207,6 +207,37 @@ delete :: forall field old .
         ) => Key field -> Book' old -> Book (old Map.:\ field)
 delete _ (Book bk) = Book $ Map.submap bk
 
+-- * Lenses
+
+-- | Build a lens from a field
+--
+-- @
+-- julian ^. rlens #age
+--    = 28
+-- @
+-- Symbols can also be used directly as lenses, so you probably don't need to use 'rlens':
+--
+-- @
+-- julian ^. #age
+--    = 28
+-- @
+--
+-- @
+-- julian & #age .~ 29
+--    = Book {age = 29, name = "Julian K. Arni"}
+-- @
+rlens :: (Settable field val' old new, Gettable field old val, Functor f) =>
+          Key field -> (val -> f val') -> (Book' old -> f (Book' new))
+rlens f = lens (\r -> get f r) (\r v -> set f v r)
+  where lens sa sbt afb s = sbt s <$> afb (sa s)
+
+instance (Settable field valnew old new,
+          Gettable field old val,
+          Functor f,
+          s2ft ~ (Book' old -> f (Book' new)))
+         => IsLabel (field :: Symbol)
+                    ((val -> f valnew) -> s2ft) where
+  fromLabel _ = rlens (Key @field)
 
 -- * Generics
 

--- a/src/Bookkeeper/Lens.hs
+++ b/src/Bookkeeper/Lens.hs
@@ -10,17 +10,21 @@ import GHC.TypeLits (Symbol, KnownSymbol, TypeError, ErrorMessage(..))
 
 -- | Build a lens from a field
 --
--- >>> julian ^. rlens #age
--- 28
--- 
+-- @
+-- julian ^. rlens #age
+--    = 28
+-- @
 -- Symbols can also be used directly as lenses, so you probably don't need to use 'rlens':
 --
--- >>> julian ^. #age
--- 28
+-- @
+-- julian ^. #age
+--    = 28
+-- @
 --
--- >>> julian & #age .~ 29
--- Book {age = 29, name = "Julian K. Arni"}
---
+-- @
+-- julian & #age .~ 29
+--    = Book {age = 29, name = "Julian K. Arni"}
+-- @
 rlens :: (Settable field val' old new, Gettable field old val, Functor f) =>
           Key field -> (val -> f val') -> (Book' old -> f (Book' new))
 rlens f = lens (\r -> get f r) (\r v -> set f v r)
@@ -34,8 +38,3 @@ instance (Settable field valnew old new,
                     ((val -> f valnew) -> s2ft) where
   fromLabel _ = rlens (Key @field)
 
--- $setup
--- >>> import Data.Function ((&))
--- >>> import Lens.Micro
--- >>> type Person = Book '[ "name" :=> String , "age" :=> Int ]
--- >>> let julian :: Person = emptyBook & #age =: 28 & #name =: "Julian K. Arni"

--- a/src/Bookkeeper/Lens.hs
+++ b/src/Bookkeeper/Lens.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Bookkeeper.Lens where
+
+import GHC.OverloadedLabels
+import Bookkeeper.Internal
+import GHC.TypeLits (Symbol, KnownSymbol, TypeError, ErrorMessage(..))
+
+-- * Lenses
+
+-- | Build a lens from a field
+--
+-- >>> julian ^. rlens #age
+-- 28
+-- 
+-- Symbols can also be used directly as lenses, so you probably don't need to use 'rlens':
+--
+-- >>> julian ^. #age
+-- 28
+--
+-- >>> julian & #age .~ 29
+-- Book {age = 29, name = "Julian K. Arni"}
+--
+rlens :: (Settable field val' old new, Gettable field old val, Functor f) =>
+          Key field -> (val -> f val') -> (Book' old -> f (Book' new))
+rlens f = lens (\r -> get f r) (\r v -> set f v r)
+  where lens sa sbt afb s = sbt s <$> afb (sa s)
+
+instance (Settable field valnew old new,
+          Gettable field old val,
+          Functor f,
+          s2ft ~ (Book' old -> f (Book' new)))
+         => IsLabel (field :: Symbol)
+                    ((val -> f valnew) -> s2ft) where
+  fromLabel _ = rlens (Key @field)
+
+-- $setup
+-- >>> import Data.Function ((&))
+-- >>> import Data.Char (toUpper)
+-- >>> import Lens.Micro
+-- >>> type Person = Book '[ "name" :=> String , "age" :=> Int ]
+-- >>> let julian :: Person = emptyBook & #age =: 28 & #name =: "Julian K. Arni"

--- a/src/Bookkeeper/Lens.hs
+++ b/src/Bookkeeper/Lens.hs
@@ -36,7 +36,6 @@ instance (Settable field valnew old new,
 
 -- $setup
 -- >>> import Data.Function ((&))
--- >>> import Data.Char (toUpper)
 -- >>> import Lens.Micro
 -- >>> type Person = Book '[ "name" :=> String , "age" :=> Int ]
 -- >>> let julian :: Person = emptyBook & #age =: 28 & #name =: "Julian K. Arni"


### PR DESCRIPTION
Inspired by the Rawr package (https://hackage.haskell.org/package/rawr), this PR adds:

* an `rlens` function that generates a lens from a record label
* an instance of IsLabel for lenses, so you can write `julian ^. #age` and `julian & #age .~ 29` by using the field labels directly as lenses and get all the goodies of you favourite lens library.

This does not add a dependency on a lens library, although the lenses are compatible with `lens` and `microlens` packages. Unfortunately without adding a dependency on one of these libraries I can't add doctests for the added functions.

Apparently the IsLabel instance is an orphan, so I have suppressed that warning.